### PR TITLE
feat: Adds metrics catalog and manages native histograms

### DIFF
--- a/backend/catalogs/api.yaml
+++ b/backend/catalogs/api.yaml
@@ -1,0 +1,12 @@
+metrics:
+  - key: "http_server_duration"
+    prom_identifier: "http_server_duration_milliseconds"
+    kind: "stats"
+    unit: "milliseconds"
+    display_as: "HTTP request duration"
+    scope: "api"
+  - key: "http_active_requests"
+    prom_identifier: "http_server_active_requests"
+    kind: "measure"
+    display_as: "Active HTTP requests"
+    scope: "api"

--- a/backend/catalogs/tasks.yaml
+++ b/backend/catalogs/tasks.yaml
@@ -1,0 +1,7 @@
+metrics:
+  - key: "celery_task_runtime"
+    prom_identifier: "flower_task_runtime_seconds"
+    kind: "stats"
+    unit: "milliseconds"
+    display_as: "Celery task runtime"
+    scope: "tasks"

--- a/backend/src/facets/entities.py
+++ b/backend/src/facets/entities.py
@@ -53,3 +53,16 @@ class LabelScrappingValue(TypedDict):
 
 
 LabelScrapping = dict[str, LabelScrappingValue]
+
+
+class Catalog(BaseModel):
+    class Metric(BaseModel):
+        key: str
+        prom_identifier: str
+        kind: MetricKind
+        scope: str
+        unit: str | None = None
+        description: str | None = None
+        display_as: str | None = None
+
+    metrics: list[Metric] = []

--- a/backend/src/facets/model.py
+++ b/backend/src/facets/model.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship

--- a/backend/src/facets/model.py
+++ b/backend/src/facets/model.py
@@ -98,4 +98,4 @@ class MetricsScrapped(Base):
     __tablename__ = "metrics_scrapped"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    ran_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, unique=True, default=lambda: datetime.now(UTC))
+    ran_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, unique=True)

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -18,6 +18,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --chmod=755 --from=build-stage /build/otelcol-dashfrog /otelcol
 
 ENTRYPOINT ["/otelcol/otelcol-dashfrog"]
-CMD ["--feature-gates=exporter.prometheusremotewritexporter.enableSendingRW2=true", "--config=/otelcol/collector-config.yaml"]
+CMD ["--feature-gates=+exporter.prometheusremotewritexporter.enableSendingRW2", "--config=/otelcol/collector-config.yaml"]
 
 EXPOSE 4317 4318 12001

--- a/dashfrog_kube/templates/collector-deployment.yaml
+++ b/dashfrog_kube/templates/collector-deployment.yaml
@@ -28,6 +28,7 @@ spec:
           image: "{{ .Values.collector.image.repository }}:{{ .Values.collector.image.tag }}"
           imagePullPolicy: {{ .Values.collector.image.pullPolicy }}
           args:
+            - "--feature-gates=+exporter.prometheusremotewritexporter.enableSendingRW2"
             - "--config"
             - "/otelcol/collector-config.yaml"
           ports:
@@ -37,8 +38,11 @@ spec:
             - name: otlp-http
               containerPort: {{ .Values.collector.config.otlpHttpPort }}
               protocol: TCP
-            - name: prometheus
+            - name: prom-remote
               containerPort: {{ .Values.collector.config.prometheusPort }}
+              protocol: TCP
+            - name: prom-metrics
+              containerPort: {{ .Values.collector.config.prometheusMetricsPort }}
               protocol: TCP
             - name: health-check
               containerPort: {{ .Values.collector.config.healthCheckPort }}

--- a/dashfrog_kube/templates/collector-service.yaml
+++ b/dashfrog_kube/templates/collector-service.yaml
@@ -18,9 +18,13 @@ spec:
       protocol: TCP
       name: otlp-http
     - port: {{ .Values.collector.service.ports.prometheus }}
-      targetPort: prometheus
+      targetPort: prom-remote
       protocol: TCP
-      name: prometheus
+      name: prom-remote
+    - port: {{ .Values.collector.service.ports.prometheusMetrics }}
+      targetPort: prom-metrics
+      protocol: TCP
+      name: prom-metrics
     - port: {{ .Values.collector.service.ports.healthCheck }}
       targetPort: health-check
       protocol: TCP

--- a/dashfrog_kube/templates/configmap-clickhouse-migrations.yaml
+++ b/dashfrog_kube/templates/configmap-clickhouse-migrations.yaml
@@ -9,12 +9,6 @@ metadata:
     purpose: migrations
 data:
   init_db.up.sql: |
-    DROP TABLE if exists dashfrog.flow_events;
-    DROP TABLE if exists dashfrog.step_events;
-    DROP TABLE if exists dashfrog.flows;
-    DROP VIEW if exists dashfrog.flows;
-    DROP VIEW if exists dashfrog.flows_mv;
-
     CREATE TABLE IF NOT EXISTS dashfrog.flow_events (
         name LowCardinality(String),
         service_name LowCardinality(Nullable(String)),
@@ -69,7 +63,7 @@ data:
     PRIMARY KEY (trace_id, name)
     ORDER BY (trace_id, name, created_at);
 
-    CREATE MATERIALIZED VIEW dashfrog.flows_mv
+    CREATE MATERIALIZED VIEW IF NOT EXISTS dashfrog.flows_mv
     REFRESH EVERY 1 MINUTES
     TO dashfrog.flows
     AS SELECT

--- a/dashfrog_kube/templates/configmap-collector.yaml
+++ b/dashfrog_kube/templates/configmap-collector.yaml
@@ -27,13 +27,27 @@ data:
         # You can configure retry / queue settings if needed
         remote_write_queue:
           enabled: true
-          num_consumers: 2
+          num_consumers: 1
           queue_size: 5000
         retry_on_failure:
           enabled: true
           initial_interval: 5s
           max_interval: 30s
           max_elapsed_time: 300s
+        resource_to_telemetry_conversion:
+          enabled: true
+        send_metadata: true
+        protobuf_message: io.prometheus.write.v2.Request
+        export_created_metric: true
+        enable_native_histograms: true
+
+      # Metadata-only exporter for all metrics
+      prometheus:
+        endpoint: "0.0.0.0:{{ .Values.collector.config.prometheusPort }}"
+        enable_open_metrics: true
+        resource_to_telemetry_conversion:
+          enabled: true
+        namespace: "meta"  # Optional, keeps metadata visually separated
     processors:
       batch:
         send_batch_size: 1000  # Tune the batch size for more efficient exporting

--- a/dashfrog_kube/templates/configmap-prometheus.yaml
+++ b/dashfrog_kube/templates/configmap-prometheus.yaml
@@ -12,10 +12,11 @@ data:
       scrape_interval: {{ .Values.prometheus.config.scrapeInterval }}
       scrape_timeout: {{ .Values.prometheus.config.scrapeTimeout }}
       scrape_protocols:
-      - OpenMetricsText1.0.0
-      - OpenMetricsText0.0.1
-      - PrometheusText1.0.0
-      - PrometheusText0.0.4
+        - PrometheusProto
+        - OpenMetricsText1.0.0
+        - OpenMetricsText0.0.1
+        - PrometheusText1.0.0
+        - PrometheusText0.0.4
     runtime:
       gogc: 75
     alerting:
@@ -28,7 +29,7 @@ data:
         static_configs:
         - targets: []
     scrape_configs:
-      - job_name: 'otel-collector'
+      - job_name: 'otel-scrape'
         static_configs:
           - targets: ['{{ include "dashfrog_kube.fullname" . }}-collector:{{ .Values.collector.config.prometheusPort }}']
     otlp:

--- a/dashfrog_kube/templates/prometheus-deployment.yaml
+++ b/dashfrog_kube/templates/prometheus-deployment.yaml
@@ -37,6 +37,7 @@ spec:
             - "--web.enable-lifecycle"
             - "--web.enable-remote-write-receiver"
             - "--enable-feature=native-histograms"
+            - "--enable-feature=metadata-wal-records"
           ports:
             - name: prometheus
               containerPort: {{ .Values.prometheus.config.port }}

--- a/dashfrog_kube/values.yaml
+++ b/dashfrog_kube/values.yaml
@@ -158,7 +158,9 @@ collector:
     otlpGrpcPort: 4317
     otlpHttpPort: 4318
     # Prometheus exporter port
-    prometheusPort: 9090
+    prometheusPort: 12001
+    # Prometheus metrics port (for /metrics endpoint)
+    prometheusMetricsPort: 9464
     # Health check port
     healthCheckPort: 13133
 
@@ -168,7 +170,8 @@ collector:
     ports:
       otlpGrpc: 4317
       otlpHttp: 4318
-      prometheus: 9090
+      prometheus: 12001
+      prometheusMetrics: 9464
       healthCheck: 13133
 
   # Resources

--- a/dashfrog_python_sdk/core.py
+++ b/dashfrog_python_sdk/core.py
@@ -88,6 +88,10 @@ class Config(BaseSettings):
         port: int | None = None
         password: str
 
+    class AttributesFilters(BaseModel):
+        instrument: str
+        accept: set[str]
+
     collector_server: str
     metric_exporter_delay: int = 3000
     auto_flow_instrumented: list[SupportedInstrumentation] = []  # use keys
@@ -96,6 +100,20 @@ class Config(BaseSettings):
 
     clickhouse: Database = Database(password="dev-pwd*")  # nosec (unsafe unused pwd)
     infra: Infra = Infra()
+    attributes_filters: list[AttributesFilters] = [
+        AttributesFilters(  # HTTPX/Request/FastAPI/Flask
+            instrument="http.*",
+            accept={"http.method", "http.route", "http.status_code", "http.url"},
+        ),
+        AttributesFilters(
+            instrument="celery.*",
+            accept={"celery.task_name", "messaging.system", "celery.retries"},
+        ),
+        AttributesFilters(
+            instrument="faas.*",
+            accept={"faas.name", "http.method", "http.route", "aws.lambda.resource_mapping.id"},
+        ),
+    ]
     auto_steps: AutoFlow | None = None
 
     model_config = SettingsConfigDict(

--- a/migrations/init_labels.up.sql
+++ b/migrations/init_labels.up.sql
@@ -25,6 +25,11 @@ CREATE TABLE metrics (
     associated_identifiers VARCHAR[]
 );
 
+CREATE TABLE metrics_scrapped (
+    id SERIAL PRIMARY KEY,
+    ran_at TIMESTAMPTZ default NOW() UNIQUE
+);
+
 CREATE TABLE label_values (
     label_id SERIAL REFERENCES labels (id) ON DELETE CASCADE ,
     value VARCHAR NOT NULL,


### PR DESCRIPTION
Adds a metrics catalog and improves metric scraping and handling.

- Introduces catalog files (`api.yaml`, `tasks.yaml`) to define and manage metrics.
- Implements logic to load and merge catalog files from the `catalogs/` directory.
- Enhances metric scraping to validate against the catalog, enriching metrics with metadata (description, display name, etc.).
- Introduces catalog lookup for metric validation
- Manages native histograms by only using a single identifier.
- Addresses duplicate metrics by selecting the one with the latest sample time.